### PR TITLE
Add QA Wolf automation AI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/import?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<!-- QA Wolf PR testing validation: add https://www.qawolf.com/automation-ai page 20260708015323 -->


### PR DESCRIPTION
This PR adds a new https://www.qawolf.com/automation-ai page. This needs new coverage for the new page.